### PR TITLE
Fix doc: swagger URL: from /api/api-docs to /api/documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ app.use('/api', baucis());
 
 Point the swagger client at your API:
 
-    http://localhost:8012/api/api-docs
+    http://localhost:8012/api/documentation
 
 Now you have documentation and a test client!
 


### PR DESCRIPTION
Fixed Swagger default URL doc: breaking change in version 1.0: from /api/api-docs to /api/documentation