### PR TITLE
Always use the collection name as plural

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -1,6 +1,5 @@
 var deco = require('deco');
 var mongoose = require('mongoose');
-var pluralize = require('mongoose/lib/utils').toCollectionName;
 
 var Model = module.exports = deco(function (options, protect) {
   var model = this;
@@ -22,7 +21,7 @@ var Model = module.exports = deco(function (options, protect) {
   };
 
   model.singular(model.modelName);
-  model.plural(pluralize(model.singular()));
+  model.plural(model.collection.name);
 });
 
 // Wrap the mongoose model function to add this mixin to all registered models.


### PR DESCRIPTION
Mongoose has deprecated `toCollectionName` because of its unpredictable behaviour (see https://github.com/Automattic/mongoose/issues/2359). To work around the strange edge cases (person->people, human->humen, ...) people usually provide the pluralized collection name by hand.

I'd like to suggest using the collection name as plural by default. This way you don't have to manually set it a  two different places.

