### PR TITLE
fixing multiple calls to response.send/response.json

### DIFF
--- a/Controller/send.js
+++ b/Controller/send.js
@@ -112,8 +112,7 @@ var decorator = module.exports = function (options, protect) {
 
     request.baucis.query.count(function (error, n) {
       if (error) return next(error);
-      response.json(n); // TODO support other content types
-      next();
+      return response.json(n); // TODO support other content types
     });
   });
 


### PR DESCRIPTION
Hi! I had a little problem when trying to get `/api/model?count=true` because response was being sent multiple times. I don't know if it's the best fix, but worked fine for me.

2 tests at your test suit were not passing, neither before nor after my fix. But at least I didn't break anything else. :)

Here's the test output:
```
  44 passing (3s)
  2 failing

  1) Controllers should handle unique key error as a validation error:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
  

  2) DEL plural "before all" hook:
     Error: Trying to open unclosed connection.
      at Context.module.exports.init (test/fixtures/vegetable.js:60:14)
```