### PR TITLE
Support for Mongoose 4.11.x cursor()

### DIFF
--- a/Controller/send.js
+++ b/Controller/send.js
@@ -125,7 +125,7 @@ var decorator = module.exports = function (options, protect) {
     // If documents were set in the baucis hash, use them.
     if (documents) pipeline(es.readArray([].concat(documents)));
     // Otherwise, stream the relevant documents from Mongo, based on constructed query.
-    else pipeline(request.baucis.query.stream());
+    else pipeline(request.baucis.query.cursor());
     // Map documents to contexts.
     pipeline(function (doc, callback) {
       callback(null, { doc: doc, incoming: null });

--- a/Controller/send.js
+++ b/Controller/send.js
@@ -125,7 +125,13 @@ var decorator = module.exports = function (options, protect) {
     // If documents were set in the baucis hash, use them.
     if (documents) pipeline(es.readArray([].concat(documents)));
     // Otherwise, stream the relevant documents from Mongo, based on constructed query.
-    else pipeline(request.baucis.query.cursor());
+    else {
+      if (request.baucis.query.op === 'findOne') {
+        pipeline(request.baucis.query.stream()); // findOne do not support cursor
+      } else {
+        pipeline(request.baucis.query.cursor());
+      }
+    }    
     // Map documents to contexts.
     pipeline(function (doc, callback) {
       callback(null, { doc: doc, incoming: null });

--- a/Controller/send.js
+++ b/Controller/send.js
@@ -177,7 +177,13 @@ var decorator = module.exports = function (options, protect) {
     // If documents were set in the baucis hash, use them.
     if (documents) pipeline(es.readArray([].concat(documents)));
     // Otherwise, stream the relevant documents from Mongo, based on constructed query.
-    else pipeline(request.baucis.query.cursor());
+    else {
+      if (request.baucis.query.op === 'findOne') {
+        pipeline(request.baucis.query.stream()); // findOne do not support cursor
+      } else {
+        pipeline(request.baucis.query.cursor());
+      }
+    } 
     // Map documents to contexts.
     pipeline(function (doc, callback) {
       callback(null, { doc: doc, incoming: null });

--- a/test/fixtures/controller.js
+++ b/test/fixtures/controller.js
@@ -46,6 +46,7 @@ mongoose.model('bal', Stores, 'stores').plural('baloo');
 
 var fixture = module.exports = {
   init: function (done) {
+    mongoose.Promise = global.Promise;
     mongoose.connect(config.mongo.url, { useMongoClient: true });
 
     // Stores controller

--- a/test/fixtures/controller.js
+++ b/test/fixtures/controller.js
@@ -46,7 +46,7 @@ mongoose.model('bal', Stores, 'stores').plural('baloo');
 
 var fixture = module.exports = {
   init: function (done) {
-    mongoose.connect(config.mongo.url);
+    mongoose.connect(config.mongo.url, { useMongoClient: true });
 
     // Stores controller
     var stores = baucis.rest('store').findBy('name').select('-hyphenated-field-name -voltaic');

--- a/test/fixtures/inheritence.js
+++ b/test/fixtures/inheritence.js
@@ -26,7 +26,7 @@ var Cordial = Liqueur.discriminator('cordial', CordialSchema);
 
 var fixture = module.exports = {
   init: function (done) {
-    mongoose.connect(config.mongo.url);
+    mongoose.connect(config.mongo.url, { useMongoClient: true });
 
     baucis.rest(Liqueur);
     baucis.rest(Amaro);

--- a/test/fixtures/subcontroller.js
+++ b/test/fixtures/subcontroller.js
@@ -25,8 +25,7 @@ mongoose.model('task', Task);
 var fixture = module.exports = {
   init: function (done) {
 
-    mongoose.connect(config.mongo.url);
-
+    connect
     var users = baucis.rest('user');
     var tasks = users.vivify('tasks');
 

--- a/test/fixtures/vegetable.js
+++ b/test/fixtures/vegetable.js
@@ -57,7 +57,7 @@ mongoose.model('animal', Animal);
 // __Module Definition__
 var fixture = module.exports = {
   init: function (done) {
-    mongoose.connect(config.mongo.url);
+    mongoose.connect(config.mongo.url, { useMongoClient: true });
 
     fixture.saveCount = 0;
     fixture.removeCount = 0;

--- a/test/fixtures/versioning.js
+++ b/test/fixtures/versioning.js
@@ -17,7 +17,7 @@ mongoose.model('pumpkin', Pumpkin).locking(true);
 var fixture = module.exports = {
   init: function (done) {
 
-    mongoose.connect(config.mongo.url);
+    mongoose.connect(config.mongo.url, { useMongoClient: true });
 
     app = express();
 

--- a/test/queries.js
+++ b/test/queries.js
@@ -199,6 +199,21 @@ describe('Queries', function () {
     });
   });
 
+  it('allows query by Id', function (done) {
+    var id = vegetables[0]._id;
+    var options = {
+      url: 'http://localhost:8012/api/vegetables/' + id,
+      json: true
+    };
+    request.get(options, function (error, response, body) {
+      if (error) return done(error);
+      expect(response.statusCode).to.be(200);
+      expect(body).to.have.property('name', 'Turnip');
+      done();
+    });
+  });
+
+
   it('allows default express query string format', function(done) {
     var options = {
       url: 'http://localhost:8012/api/vegetables?conditions[name]=Radicchio',
@@ -820,7 +835,7 @@ describe('Queries', function () {
     });
   });
 
-  it('should give a 400 if the query stirng is unpar using query operators with _id', function (done) {
+  it('should give a 400 if the query string is unpar using query operators with _id', function (done) {
     var options = {
       url: 'http://localhost:8012/api/vegetables?conditions={ \'_id\': { \'$gt\': \'111111111111111111111111\' } }',
       json: true
@@ -828,7 +843,11 @@ describe('Queries', function () {
     request.get(options, function (error, response, body) {
       if (error) return done(error);
       expect(response.statusCode).to.be(400);
-      expect(body).to.have.property('message', 'The conditions query string value was not valid JSON: "Unexpected token \'" (400).');
+      // before:  'The conditions query string value was not valid JSON: "Unexpected token \'" (400).'
+      // after:   'The conditions query string value was not valid JSON: "Unexpected token \' in JSON at position 2" (400).'
+      // test changed to be less fragile
+      expect(body).to.have.property('message');
+      expect(body.message).to.contain('The conditions query string value was not valid JSON: "Unexpected token \'');
       done();
     });
   });

--- a/test/versioning.js
+++ b/test/versioning.js
@@ -65,6 +65,7 @@ describe('Versioning', function () {
     request.get(options, function (err, response, body) {
       if (err) return done(err);
       expect(response.statusCode).to.be(400);
+      expect(response.headers['content-type']).to.contain('text/html');  // I would expect JSON instead of html as negociated with json: true in the caller
       // now is HTML / before was plain/text
       expect(body).to.contain('Bad Request: The requested API version range &quot;&gt;3.0.1&quot; could not be satisfied (400).');
       expect(response.headers).not.to.have.property('api-version');

--- a/test/versioning.js
+++ b/test/versioning.js
@@ -65,7 +65,8 @@ describe('Versioning', function () {
     request.get(options, function (err, response, body) {
       if (err) return done(err);
       expect(response.statusCode).to.be(400);
-      expect(body).to.be('Bad Request: The requested API version range &quot;&gt;3.0.1&quot; could not be satisfied (400).\n');
+      // now is HTML / before was plain/text
+      expect(body).to.contain('Bad Request: The requested API version range &quot;&gt;3.0.1&quot; could not be satisfied (400).');
       expect(response.headers).not.to.have.property('api-version');
       done();
     });


### PR DESCRIPTION
Fixes #326 
- Discovered that the mongoose `findOne` operation do not support `cursor()`. Review the proposed fix please.
- Added useMongoClient: true to connect() in tests
- Fixed some broken tests (mime type changed from text/plain to text/html but tests were not updated)
- Any way, such behaviour should honor accept header and return application/json instead
- Saw no more mongoose warnings in my tests

Tested with mongoose 4.11.14 and express 4.16.1