### PR TITLE
Fix/mongoose peer dep version

### DIFF
--- a/Controller/errors.js
+++ b/Controller/errors.js
@@ -133,6 +133,7 @@ var decorator = module.exports = function (options, protect) {
         Object.getOwnPropertyNames(error3).forEach(function(key) {
           o[key] = error3[key];
         });
+        o.name = o.name || 'ValidatorError';
         delete o.domain;
         delete o.domainEmitter;
         delete o.domainThrown;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "semver": "^4.3.4"
   },
   "peerDependencies": {
-    "mongoose": ">=3 <5",
+    "mongoose": ">=5",
     "express": "^4.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
PR #335 breaks backwards compatibility. Changing mongoose peer dependency version to >=5.